### PR TITLE
Define API for resetting

### DIFF
--- a/src/firecracker/src/api_server/request/checkpoint.rs
+++ b/src/firecracker/src/api_server/request/checkpoint.rs
@@ -1,0 +1,61 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use micro_http::{Method, StatusCode};
+use vmm::rpc_interface::VmmAction;
+
+use crate::api_server::parsed_request::{ParsedRequest, RequestError};
+
+pub(crate) fn parse_put_checkpoint(
+    request_type_from_path: Option<&str>,
+) -> Result<ParsedRequest, RequestError> {
+    match request_type_from_path {
+        Some(request_type) => match request_type {
+            "create" => parse_put_checkpoint_create(),
+            "load" => parse_put_checkpoint_load(),
+            _ => Err(RequestError::InvalidPathMethod(
+                format!("/checkpoint/{}", request_type),
+                Method::Put,
+            )),
+        },
+        None => Err(RequestError::Generic(
+            StatusCode::BadRequest,
+            "Missing checkpoint operation type.".to_string(),
+        )),
+    }
+}
+
+fn parse_put_checkpoint_create() -> Result<ParsedRequest, RequestError> {
+    let parsed_request = ParsedRequest::new_sync(VmmAction::CreateCheckpoint);
+
+    Ok(parsed_request)
+}
+
+fn parse_put_checkpoint_load() -> Result<ParsedRequest, RequestError> {
+    let parsed_request = ParsedRequest::new_sync(VmmAction::LoadCheckpoint);
+
+    Ok(parsed_request)
+}
+
+#[cfg(test)]
+mod tests {
+    use vmm::rpc_interface::VmmAction;
+
+    use crate::api_server::parsed_request::tests::vmm_action_from_request;
+    use crate::api_server::request::checkpoint::parse_put_checkpoint;
+
+    #[test]
+    fn test_parse_put_checkpoint() {
+        assert_eq!(
+            vmm_action_from_request(parse_put_checkpoint(Some("create")).unwrap()),
+            VmmAction::CreateCheckpoint
+        );
+
+        assert_eq!(
+            vmm_action_from_request(parse_put_checkpoint(Some("load")).unwrap()),
+            VmmAction::LoadCheckpoint
+        );
+
+        parse_put_checkpoint(None).unwrap_err();
+    }
+}

--- a/src/firecracker/src/api_server/request/mod.rs
+++ b/src/firecracker/src/api_server/request/mod.rs
@@ -4,6 +4,7 @@
 pub mod actions;
 pub mod balloon;
 pub mod boot_source;
+pub mod checkpoint;
 pub mod cpu_configuration;
 pub mod drive;
 pub mod entropy;


### PR DESCRIPTION
## Changes

Define two new API endpoints for in-memory resetting: /checkpoint/create and /checkpoint/load.

This mirrors the naming conventions used by
snapshotting. To do: Update Swagger

## Reason

This is the starting point  for in-memory VM resetting. The implementation can be built off of this API.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
